### PR TITLE
Support kubernetes 1.30 and 1.31

### DIFF
--- a/tasks/bootstrap_image.sh
+++ b/tasks/bootstrap_image.sh
@@ -56,6 +56,8 @@ echo "Setting DEBIAN_FRONTEND=noninteractive to run in unattended manner"
 export DEBIAN_FRONTEND=noninteractive
 echo "Removing cloud-initramfs-tools (bug #1967593 on launchpad)"
 apt -y -o=Dpkg::Use-Pty=0 remove cloud-initramfs-copymods
+echo "Installing dosfstools to handle boot/firmware partition"
+apt -y -o=Dpkg::Use-Pty=0 install dosfstools
 echo "Installing containerd"
 apt -y -o=Dpkg::Use-Pty=0 install containerd
 echo "Configuring containerd. Errors related to /proc/cpuinfo can be safely ignored."

--- a/tasks/update_image_partition.sh
+++ b/tasks/update_image_partition.sh
@@ -23,8 +23,8 @@ IMAGE_DEV=`echo "$ALL_DEV" | grep 'LABEL="image"'| head -n 1  | awk -F':' {'prin
 if [ "$LOCAL_IMAGE_PATH" = "" ] ; then
   #FIXME: Check free space before downloading.
   #FIXME: Add checksum verification.
-  echo "Downloading boot image from $HTTP_IMAGE_URL"
-  curl -Lo /boot.img.xz $HTTP_IMAGE_URL/boot.img.xz
+  echo "Downloading boot archive from $HTTP_IMAGE_URL"
+  curl -Lo /boot.tar.xz $HTTP_IMAGE_URL/boot.tar.xz
   echo "Downloading image from $HTTP_IMAGE_URL"
   curl -Lo /image.img.xz $HTTP_IMAGE_URL/image.img.xz
 fi
@@ -37,33 +37,42 @@ if  ! xz -t $LOCAL_IMAGE_PATH/image.img.xz ; then
   echo "ERROR: local installation image $LOCAL_IMAGE_PATH/image.img.xz is not an xz archive. Exiting."
   exit 1
 fi
-if [ ! -r "$LOCAL_IMAGE_PATH"/boot.img.xz ] ; then
-  echo "ERROR: cannot read local boot image $LOCAL_IMAGE_PATH/boot.img.xz. Exiting."
+if [ ! -r "$LOCAL_IMAGE_PATH"/boot.tar.xz ] ; then
+  echo "ERROR: cannot read local boot archive $LOCAL_IMAGE_PATH/boot.tar.xz. Exiting."
 exit 1
 fi
-if  ! xz -t $LOCAL_IMAGE_PATH/boot.img.xz  ; then
-  echo "ERROR: local boot image $LOCAL_IMAGE_PATH/boot.img.xz is not an xz archive. Exiting."
+if  ! xz -t $LOCAL_IMAGE_PATH/boot.tar.xz  ; then
+  echo "ERROR: local boot archive $LOCAL_IMAGE_PATH/boot.tar.xz is not an xz archive. Exiting."
   exit 1
 fi
 
 # Remote images are downloaded to / when LOCAL_IMAGE_PATH is empty, so the
 # following extraction procedure works for both local and remote cases.
-echo "Writing image $LOCAL_IMAGE_PATH/boot.img.xz to image partition $BOOT_DEV"
-unxz -v --stdout $LOCAL_IMAGE_PATH/boot.img.xz | dd of=$BOOT_DEV bs=100M
 echo "Writing image $LOCAL_IMAGE_PATH/image.img.xz to image partition $IMAGE_DEV"
 unxz -v --stdout $LOCAL_IMAGE_PATH/image.img.xz | dd of=$IMAGE_DEV bs=100M
-
+echo "Re-formatting boot partition to make sure it's clean."
+umount $BOOT_DEV
+mkfs.vfat $BOOT_DEV
+fatlabel $BOOT_DEV system-boot
+echo "Mounting /boot/firmware mountpoint where $BOOT_DEV is expected"
+echo "to be mounted. There can be an error if the layout changes in future"
+echo "releases of Ubuntu. In this case, this should be reported as a bug."
+mount /boot/firmware
+echo "Extracting updated boot and firmware files."
+tar xvf $LOCAL_IMAGE_PATH/boot.tar.xz -C /boot/firmware
+echo "Unmounting /boot/firmware partition for future operations."
+umount /boot/firmware
 echo "Verifying FS at target partitions $BOOT_DEV"
 fsck.vfat -a $BOOT_DEV || true
 echo "Verifying FS at target partition $IMAGE_DEV"
 # e2fsck will return error when fixing a corrupted FS, so need to suppress it
 e2fsck -yf $IMAGE_DEV || true
+mount $BOOT_DEV
 echo "Resizing fs on image partition $IMAGE_DEV to all available space"
 resize2fs $IMAGE_DEV
-echo "Injecting installation images into FS on image partition"
+echo "Injecting installation image into FS on image partition"
 IMAGE_PART_DIR=`mktemp -d`
 mount $IMAGE_DEV $IMAGE_PART_DIR
-cp $LOCAL_IMAGE_PATH/boot.img.xz $IMAGE_PART_DIR/
 cp $LOCAL_IMAGE_PATH/image.img.xz $IMAGE_PART_DIR/
 umount $IMAGE_PART_DIR
 # if there were any changes, they will need yet another fsck to mark it clean

--- a/tasks/update_working_partition.sh
+++ b/tasks/update_working_partition.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ ! -r /boot.img.xz ] ; then
-  echo "Firmware/efi FS image file /boot.img.xz not found. Aborting installation."
-  exit 1
-fi
-
 if [ ! -r /image.img.xz ] ; then
   echo "Root FS image file /image.img.xz not found. Aborting installation."
   exit 1
@@ -43,9 +38,6 @@ echo "fixing FS at target partition $WORKING_PARTITION"
 e2fsck -yf $WORKING_PARTITION || true
 echo "Resizing fs on working partition $WORKING_PARTITION to all available space"
 resize2fs $WORKING_PARTITION
-echo "Setting boot target to working partition $WORKING_PARTITION"
-e2label $WORKING_PARTITION writable
-e2label $IMAGE_PARTITION image
 
 TEMP_DIR=`mktemp -d`
 mount $WORKING_PARTITION $TEMP_DIR
@@ -64,3 +56,7 @@ umount $TEMP_DIR
 echo "Checking fs on updated working partition."
 # e2fsck will return error when fixing a corrupted FS, so need to suppress it
 e2fsck -yf $WORKING_PARTITION || true
+
+echo "Setting boot target to working partition $WORKING_PARTITION"
+e2label $WORKING_PARTITION writable
+e2label $IMAGE_PARTITION image

--- a/variables.cfg.example
+++ b/variables.cfg.example
@@ -2,11 +2,11 @@
 # MUST be present under current directory, must be an uncompressed image (not
 # img.xz).
 # Example:
-#IMAGE=ubuntu-22.04.4-preinstalled-server-arm64+raspi.img
+#IMAGE=ubuntu-24.04.1-preinstalled-server-arm64+raspi.img
 IMAGE=
 
 #K8S version to use
-K8S_VERSION=1.29.1
+K8S_VERSION=1.30.0
 
 #While not mandatory, it is a good idea to have a DNS name or at least a fixed
 #IP-address associated with your master's MAC address. Otherwise, when your


### PR DESCRIPTION
Other changes:
- add an option to autodetach stale loopback devices left from previous build
- fix grep behavior to make updating ssh keys more reliable
- instead of using vfat image for /boot/firmware, use archive with required files due to instability on vfat management tools in linux.
- fix restart logic of kubernetes API server and etcd during install/upgrade
- skip kubeadm check for being able to schedule a pod since its "error out" behavior is not desired in unmaintained setups
- use ubuntu 24.04 by default